### PR TITLE
Fix <hr> styling

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -192,12 +192,11 @@ ul, ol, dl {
 /* COMMON STYLES */
 
 hr {
-  height: 1px;
-  line-height: 1px;
+  height: 0;
   margin-top: 1em;
-  padding-bottom: 1em;
-  border: none;
-  background: transparent url('../images/hr.png') 0 0 no-repeat;
+  margin-bottom: 1em;
+  border: 0;
+  border-top: solid 1px #ddd;
 }
 
 table {


### PR DESCRIPTION
Fixes #2.

The existing `<hr>` rule has been relying on a non-existent `hr.png` file all along. I don't know if I forgot to include it originally or if I copy/pasted this block from somewhere else. Regardless, this is a silly place to use an image, so this fixes the rule to just use a border.

/cc @pietromenna
