### PR TITLE
Add space before GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       <div class="inner">
         <h1>Architect Theme</h1>
         <h2>Open Source version of the GitHub Pages theme</h2>
-        <a href="https://github.com/jasonlong/architect-theme" class="button"><small>View project on</small>GitHub</a>
+        <a href="https://github.com/jasonlong/architect-theme" class="button"><small>View project on</small> GitHub</a>
       </div>
     </header>
 


### PR DESCRIPTION
Previously, there was a missing space that caused the words "on" and "GitHub" to run together on mobile.
