### PR TITLE
Switch to normalize.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         <section id="main-content">
 
         <h1>Headline 1</h1>
-        <p><strong>Lorem ipsizzle funky</strong> fresh i'm <em>in the shizzle</em> boom shackalack, consectetizzle adipiscing my shizz. Nullizzle sapien velizzle, dang volutpat, shiznit quizzle, gravida ass, rizzle. Pot get down get down tortor. Sed erizzle. Black go to hizzle dolizzle dapibizzle turpis fo shizzle my nizzle yo. Maurizzle pellentesque nibh et check it out. Bow wow wow check it out tortizzle. Pellentesque for sure rhoncizzle bow wow wow. In owned habitasse brizzle dictumst. Nizzle dapibizzle. Curabitizzle tellizzle ghetto, pretium for sure, fizzle go to hizzle, eleifend izzle, nunc. Dope suscipizzle. Integizzle boom shackalack velit ass purus.</p>
+        <p>Lorem ipsizzle funky fresh i'm in the shizzle boom shackalack, consectetizzle adipiscing my shizz. Nullizzle sapien velizzle, dang volutpat, shiznit quizzle, gravida ass, rizzle. Pot get down get down tortor. Sed erizzle. Black go to hizzle dolizzle dapibizzle turpis fo shizzle my nizzle yo. Maurizzle pellentesque nibh et check it out. Bow wow wow check it out tortizzle. Pellentesque for sure rhoncizzle bow wow wow. In owned habitasse brizzle dictumst. Nizzle dapibizzle. Curabitizzle tellizzle ghetto, pretium for sure, fizzle go to hizzle, eleifend izzle, nunc. Dope suscipizzle. Integizzle boom shackalack velit ass purus.</p>
 
         <div class="highlight">
         <pre><span class="nb">require</span> <span class="s1">'redcarpet'</span>


### PR DESCRIPTION
As reported in #5, the reset.css used in this theme doesn't allow for inline styling (e.g. bold, italics, etc.). Due to the nature of these older resets, they are pretty overzealous and try to reset every element to have zero styling. Using [normalize.css](http://necolas.github.io/normalize.css/) is a much better way of establishing a baseline style so I've swapped that in.

@pietromenna I'd prefer we go with this over band-aiding the reset styles in #6.
