### PR TITLE
fix inside list items containing block elements in Firefox

### DIFF
--- a/stylesheets/print.css
+++ b/stylesheets/print.css
@@ -186,12 +186,14 @@ blockquote {
 }
 
 ul li {
-  list-style: disc inside;
+  list-style-position: inside;
+  list-style: disc;
   padding-left: 20px;
 }
 
 ol li {
-  list-style: decimal inside;
+  list-style-position: inside;
+  list-style: decimal;
   padding-left: 3px;
 }
 

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -725,12 +725,14 @@ blockquote {
 }
 
 ul {
-  list-style: disc inside;
+  list-style-position: inside;
+  list-style: disc;
   padding-left: 20px;
 }
 
 ol {
-  list-style: decimal inside;
+  list-style-position: inside;
+  list-style: decimal;
   padding-left: 3px;
 }
 


### PR DESCRIPTION
There is an issue with Firefox and list items that include block elements, such as paragraphs and the inside property (according to http://stackoverflow.com/questions/1142314/css-rendering-inconsistency-on-ul-with-firefox-being-the-odd-ball-out).

This fixes the issue.
