### PR TITLE
fixing lists in Firefox (again)

### DIFF
--- a/stylesheets/print.css
+++ b/stylesheets/print.css
@@ -187,14 +187,14 @@ blockquote {
 
 ul li {
   padding-left: 20px;
-  list-style: disc;
   list-style-position: inside;
+  list-style: disc;
 }
 
 ol li {
   padding-left: 3px;
-  list-style: disc;
   list-style-position: inside;
+  list-style: decimal;
 }
 
 dl dd {

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -725,15 +725,15 @@ blockquote {
 }
 
 ul {
-  padding-left: 20px;
-  list-style: disc;
   list-style-position: inside;
+  list-style: disc;
+  padding-left: 20px;
 }
 
 ol {
-  padding-left: 3px;
-  list-style: disc;
   list-style-position: inside;
+  list-style: decimal;
+  padding-left: 3px;
 }
 
 dl dd {


### PR DESCRIPTION
@jasonlong, sorry but I’m afraid that (manual?) merging was wrong.

It seems that `list-style-position` should come before `list-style` (otherwise, Firefox displays the list wrong).

BTW, ordered lists should have `list-style: decimal;`. With `list-style: disc;` they are unordered lists.
