### PR TITLE
allow the user to align the <td> element (fixes #17)

### DIFF
--- a/stylesheets/print.css
+++ b/stylesheets/print.css
@@ -122,6 +122,18 @@ td {
   border: 1px solid #ebebeb;
 }
 
+td[align="left"] {
+  text-align: left;
+}
+
+td[align="right"] {
+  text-align: right;
+}
+
+td[align="justify"] {
+  text-align: justify;
+}
+
 form {
   padding: 20px;
   background: #f2f2f2;


### PR DESCRIPTION
It is great to have a default aligment of `<td>`, but if the user aligns cells, default shouldn’t be applied.

I hope it helps to fix #17.