### PR TITLE
remove default centering in <td> (fixes #17)

### DIFF
--- a/stylesheets/print.css
+++ b/stylesheets/print.css
@@ -118,8 +118,6 @@ th {
 
 td {
   font-weight: 300;
-  text-align: center;
-  border: 1px solid #ebebeb;
 }
 
 form {


### PR DESCRIPTION
remove also redundant code (already inherited from `<table>`)